### PR TITLE
feat(router): add route conflict detection, validation, and optional specificity ordering

### DIFF
--- a/builder_test.go
+++ b/builder_test.go
@@ -409,6 +409,10 @@ func (m *MockRouter) Routes() []router.RouteDefinition {
 	return []router.RouteDefinition{}
 }
 
+func (m *MockRouter) ValidateRoutes() []error {
+	return nil
+}
+
 func (m *MockRouter) Use(mw ...router.MiddlewareFunc) router.Router[*MockRouter] {
 	m.Mw = append(m.Mw, mw...)
 	return m

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/goliatone/go-composite-fs v0.3.0
 	github.com/goliatone/go-errors v0.10.0
 	github.com/goliatone/go-featuregate v0.5.0
-	github.com/goliatone/hashid v0.1.1
+	github.com/goliatone/hashid v0.2.0
 	github.com/goodsign/monday v1.0.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
@@ -37,6 +37,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0 // indirect
+	github.com/goliatone/go-slug v0.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/lithammer/shortuuid v3.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,10 @@ github.com/goliatone/go-errors v0.10.0 h1:qVmOXKq6aa3cHbygI5VHGCosuA0CLAXso0Blin
 github.com/goliatone/go-errors v0.10.0/go.mod h1:FiZEC2z5a8SBdRyljC9wFt+IzqZDfrst2dPoqWARbr4=
 github.com/goliatone/go-featuregate v0.5.0 h1:Lpm9IdAapzdCih6RYsQY241YSSGQ4tEQxIVNjrZuvRs=
 github.com/goliatone/go-featuregate v0.5.0/go.mod h1:VYc0O3RXNTqa0TuI9biHOt2WSFbilnUkiSljcvMU4XA=
-github.com/goliatone/hashid v0.1.1 h1:VfZZf7s0uM+JZ3ZBkqaEM1mL/CJfiTmFOzZ1QuXY3EM=
-github.com/goliatone/hashid v0.1.1/go.mod h1:K9jzegsVvT8S+Nn5wL1AuGVKcz2jcwYMxwe4g1UGz4E=
+github.com/goliatone/go-slug v0.1.0 h1:0APBcu2X9MWF2t6X3LN55XfQ47zf4FUzDmXYJ1YraAk=
+github.com/goliatone/go-slug v0.1.0/go.mod h1:8lXx322OHfQQzdrwikY2uqhQVmH3IVNGiVxn9kPmX1w=
+github.com/goliatone/hashid v0.2.0 h1:Q+OkMo+JX2FCok72BetkmniSIuV4YYj9JUhUZAjRDZ4=
+github.com/goliatone/hashid v0.2.0/go.mod h1:jgEJQBDWz7OSe4uWCcsu5rkb4HtKTNvgF4Wl3NPfC6E=
 github.com/goodsign/monday v1.0.2 h1:k8kRMkCRVfCTWOU4dRfRgneQsWlB1+mJd3MxG0lGLzQ=
 github.com/goodsign/monday v1.0.2/go.mod h1:r4T4breXpoFwspQNM+u2sLxJb2zyTaxVGqUfTBjWOu8=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/path_helpers.go
+++ b/path_helpers.go
@@ -59,3 +59,17 @@ func MustSubFS(base fs.FS, subdir string) fs.FS {
 	}
 	return sub
 }
+
+// PathParam returns a parameter segment (e.g., ":id").
+func PathParam(name string) string {
+	return ":" + name
+}
+
+// ConstrainedPathParam returns a parameter segment with a constraint.
+// Note: constraint syntax is Fiber-specific; httprouter treats it as part of the param name.
+func ConstrainedPathParam(name, constraint string) string {
+	if constraint == "" {
+		return ":" + name
+	}
+	return ":" + name + "<" + constraint + ">"
+}

--- a/route_conflicts.go
+++ b/route_conflicts.go
@@ -1,0 +1,126 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	goerrors "github.com/goliatone/go-errors"
+)
+
+type routeConflict struct {
+	existing        *RouteDefinition
+	reason          string
+	index           int
+	existingSegment string
+	newSegment      string
+}
+
+type segmentKind int
+
+const (
+	segmentStatic segmentKind = iota
+	segmentParam
+	segmentCatchAll
+)
+
+func splitPathSegments(path string) []string {
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil
+	}
+	return strings.Split(trimmed, "/")
+}
+
+func classifySegment(segment string) segmentKind {
+	if strings.HasPrefix(segment, "*") {
+		return segmentCatchAll
+	}
+	if strings.HasPrefix(segment, ":") {
+		return segmentParam
+	}
+	return segmentStatic
+}
+
+func detectPathConflict(existingPath, newPath string) *routeConflict {
+	existingParts := splitPathSegments(existingPath)
+	newParts := splitPathSegments(newPath)
+
+	minLen := len(existingParts)
+	if len(newParts) < minLen {
+		minLen = len(newParts)
+	}
+
+	for i := 0; i < minLen; i++ {
+		existingSegment := existingParts[i]
+		newSegment := newParts[i]
+		existingKind := classifySegment(existingSegment)
+		newKind := classifySegment(newSegment)
+
+		if existingKind == segmentStatic && newKind == segmentStatic {
+			if existingSegment != newSegment {
+				return nil
+			}
+			continue
+		}
+
+		if existingKind == segmentCatchAll || newKind == segmentCatchAll {
+			return &routeConflict{
+				reason:          "catch-all segment conflicts with existing route",
+				index:           i,
+				existingSegment: existingSegment,
+				newSegment:      newSegment,
+			}
+		}
+
+		if existingKind == segmentParam && newKind == segmentParam {
+			if i == len(existingParts)-1 && i == len(newParts)-1 {
+				return &routeConflict{
+					reason:          "wildcard segment conflicts with existing route",
+					index:           i,
+					existingSegment: existingSegment,
+					newSegment:      newSegment,
+				}
+			}
+			continue
+		}
+
+		if existingKind == segmentParam || newKind == segmentParam {
+			return &routeConflict{
+				reason:          "static segment conflicts with wildcard segment",
+				index:           i,
+				existingSegment: existingSegment,
+				newSegment:      newSegment,
+			}
+		}
+	}
+
+	return nil
+}
+
+func newRouteConflictError(method HTTPMethod, path string, conflict *routeConflict, policy HTTPRouterConflictPolicy) error {
+	message := fmt.Sprintf("route conflict: %s %s conflicts with %s", method, path, conflict.existing.Path)
+	if conflict.reason != "" {
+		message = fmt.Sprintf("%s (%s)", message, conflict.reason)
+	}
+
+	metadata := map[string]any{
+		"adapter":       "shared",
+		"method":        method,
+		"path":          path,
+		"existing_path": conflict.existing.Path,
+		"policy":        policy.String(),
+		"reason":        conflict.reason,
+	}
+
+	if conflict.index >= 0 {
+		metadata["segment_index"] = conflict.index
+		metadata["segment"] = conflict.newSegment
+		metadata["existing_segment"] = conflict.existingSegment
+	}
+
+	return goerrors.New(message, goerrors.CategoryConflict).
+		WithCode(http.StatusConflict).
+		WithTextCode("ROUTE_CONFLICT").
+		WithMetadata(metadata)
+}

--- a/route_specificity.go
+++ b/route_specificity.go
@@ -1,0 +1,64 @@
+package router
+
+import "sort"
+
+func sortRoutesBySpecificity(routes []*RouteDefinition) {
+	sort.SliceStable(routes, func(i, j int) bool {
+		left := routes[i]
+		right := routes[j]
+		if left.Method != right.Method {
+			return false
+		}
+		return compareRouteSpecificity(left.Path, right.Path) > 0
+	})
+}
+
+func compareRouteSpecificity(leftPath, rightPath string) int {
+	leftParts := splitPathSegments(leftPath)
+	rightParts := splitPathSegments(rightPath)
+
+	minLen := len(leftParts)
+	if len(rightParts) < minLen {
+		minLen = len(rightParts)
+	}
+
+	for i := 0; i < minLen; i++ {
+		leftSegment := leftParts[i]
+		rightSegment := rightParts[i]
+		leftKind := classifySegment(leftSegment)
+		rightKind := classifySegment(rightSegment)
+
+		if leftKind != rightKind {
+			return compareSegmentKind(leftKind, rightKind)
+		}
+
+		if leftKind == segmentStatic && leftSegment != rightSegment {
+			return 0
+		}
+	}
+
+	if len(leftParts) != len(rightParts) {
+		if len(leftParts) > len(rightParts) {
+			return 1
+		}
+		return -1
+	}
+
+	return 0
+}
+
+func compareSegmentKind(left, right segmentKind) int {
+	if left == right {
+		return 0
+	}
+	if left == segmentStatic {
+		return 1
+	}
+	if right == segmentStatic {
+		return -1
+	}
+	if left == segmentParam {
+		return 1
+	}
+	return -1
+}

--- a/route_validation.go
+++ b/route_validation.go
@@ -1,0 +1,124 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	goerrors "github.com/goliatone/go-errors"
+)
+
+func (br *BaseRouter) ValidateRoutes() []error {
+	routes := make([]*RouteDefinition, 0, len(br.root.routes)+len(br.root.lateRoutes))
+	routes = append(routes, br.root.routes...)
+	for _, late := range br.root.lateRoutes {
+		routes = append(routes, &RouteDefinition{
+			Method: late.method,
+			Path:   late.path,
+		})
+	}
+	return ValidateRouteDefinitions(routes)
+}
+
+// ValidateRouteDefinitions checks for conflicting or ambiguous routes.
+func ValidateRouteDefinitions(routes []*RouteDefinition) []error {
+	var errs []error
+
+	for i := 0; i < len(routes); i++ {
+		for j := i + 1; j < len(routes); j++ {
+			left := routes[i]
+			right := routes[j]
+			if left.Method != right.Method {
+				continue
+			}
+
+			if left.Path == right.Path {
+				conflict := &routeConflict{
+					existing: left,
+					reason:   "duplicate route",
+					index:    -1,
+				}
+				errs = append(errs, newRouteConflictError(left.Method, right.Path, conflict, HTTPRouterConflictPanic))
+				continue
+			}
+
+			if conflict := detectPathConflict(left.Path, right.Path); conflict != nil {
+				conflict.existing = left
+				errs = append(errs, newRouteConflictError(left.Method, right.Path, conflict, HTTPRouterConflictPanic))
+			}
+
+			if lintErr := detectBareIDParamLint(left, right); lintErr != nil {
+				errs = append(errs, lintErr)
+			}
+			if lintErr := detectBareIDParamLint(right, left); lintErr != nil {
+				errs = append(errs, lintErr)
+			}
+		}
+	}
+
+	return errs
+}
+
+func detectBareIDParamLint(paramRoute, staticRoute *RouteDefinition) error {
+	if paramRoute.Method != staticRoute.Method {
+		return nil
+	}
+
+	paramParts := splitPathSegments(paramRoute.Path)
+	staticParts := splitPathSegments(staticRoute.Path)
+	if len(paramParts) != len(staticParts) {
+		return nil
+	}
+
+	for i, paramSegment := range paramParts {
+		name, constraint, ok := parseParamSegment(paramSegment)
+		if !ok || name != "id" || constraint != "" {
+			continue
+		}
+		if classifySegment(staticParts[i]) != segmentStatic {
+			continue
+		}
+
+		for k := 0; k < len(paramParts); k++ {
+			if k == i {
+				continue
+			}
+			if paramParts[k] != staticParts[k] {
+				return nil
+			}
+		}
+
+		return newRouteLintError(paramRoute.Method, paramRoute.Path, staticRoute.Path, name)
+	}
+
+	return nil
+}
+
+func parseParamSegment(segment string) (name string, constraint string, ok bool) {
+	if !strings.HasPrefix(segment, ":") {
+		return "", "", false
+	}
+	raw := strings.TrimPrefix(segment, ":")
+	if raw == "" {
+		return "", "", false
+	}
+	if idx := strings.Index(raw, "<"); idx >= 0 && strings.HasSuffix(raw, ">") {
+		return raw[:idx], raw[idx+1 : len(raw)-1], true
+	}
+	return raw, "", true
+}
+
+func newRouteLintError(method HTTPMethod, path, siblingPath, param string) error {
+	message := fmt.Sprintf("route lint: %s %s uses bare :%s with static sibling %s; consider constraining the param", method, path, param, siblingPath)
+	metadata := map[string]any{
+		"method":       method,
+		"path":         path,
+		"sibling_path": siblingPath,
+		"param":        param,
+	}
+
+	return goerrors.New(message, goerrors.CategoryConflict).
+		WithCode(http.StatusConflict).
+		WithTextCode("ROUTE_LINT").
+		WithMetadata(metadata)
+}

--- a/router.go
+++ b/router.go
@@ -256,6 +256,7 @@ type Router[T any] interface {
 
 	// TODO: Move to a different interface e.g. MetaRouter
 	Routes() []RouteDefinition
+	ValidateRoutes() []error
 	// For debugging: Print a table of routes and their middleware chain
 	PrintRoutes()
 	WithLogger(logger Logger) Router[T]

--- a/router_base.go
+++ b/router_base.go
@@ -14,9 +14,11 @@ import (
 )
 
 type routerRoot struct {
-	routes      []*RouteDefinition
-	namedRoutes map[string]*RouteDefinition
-	lateRoutes  []*lateRoute
+	routes             []*RouteDefinition
+	namedRoutes        map[string]*RouteDefinition
+	lateRoutes         []*lateRoute
+	deferredRoutes     []*RouteDefinition
+	deferredRegistered bool
 }
 
 // Common fields for both FiberRouter and HTTPRouter


### PR DESCRIPTION
This PR adds shared route conflict detection, optional strict route validation, and an optin specificity based registration order for Fiber. It also introduces constrained path param helpers and a lint to flag bare `:id` when a static sibling exists

**Changes**:
- add shared conflict detection + error construction
- add route validation + lint for bare `:id` with static sibling
- add optional specificity sort for deferred Fiber registration 
- add Fiber config options: `ConflictPolicy`, `StrictRoutes`, `OrderRoutesBySpecificity`
- add HTTP server strict routes option and new conflict policy `log_and_continue`
- add helpers `PathParam` and `ConstrainedPathParam`
- add `ValidateRoutes()` to `Router` interface and mock implementations
